### PR TITLE
feat/add-intentional-collaborative-frameworks/matbgn

### DIFF
--- a/package.json
+++ b/package.json
@@ -140,5 +140,18 @@
     "typescript-eslint": "^8.0.1",
     "vite": "^6.3.4",
     "vitest": "^4.0.18"
-  }
+  },
+  "description": "<div align=\"center\">   <img src=\"public/P3Fo_Logo.svg\" alt=\"P3Fo Logo\" width=\"200\" /> </div>",
+  "main": "eslint.config.js",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/matbgn/p3fo.git"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "bugs": {
+    "url": "https://github.com/matbgn/p3fo/issues"
+  },
+  "homepage": "https://github.com/matbgn/p3fo#readme"
 }

--- a/server/db/index.ts
+++ b/server/db/index.ts
@@ -1,5 +1,5 @@
 // Database client interface and factory
-import { TaskEntity, UserSettingsEntity, AppSettingsEntity, QolSurveyResponseEntity, FilterStateEntity, FertilizationBoardEntity, DreamBoardEntity, CircleEntity, ReminderEntity } from '../../src/lib/persistence-types.js';
+import { TaskEntity, UserSettingsEntity, AppSettingsEntity, QolSurveyResponseEntity, FilterStateEntity, FertilizationBoardEntity, DreamBoardEntity, CircleEntity, ReminderEntity, FrameworkEntity, FrameworkType } from '../../src/lib/persistence-types.js';
 
 // Pagination options for queries
 export interface PaginationOptions {
@@ -77,6 +77,14 @@ export interface DbClient {
   deleteCircle(id: string): Promise<void>;
   clearAllCircles(): Promise<void>;
   importCircles(circles: CircleEntity[]): Promise<void>;
+
+  // Frameworks
+  getFrameworks(frameworkType?: string): Promise<FrameworkEntity[]>;
+  getFrameworkById(id: string): Promise<FrameworkEntity | null>;
+  createFramework(framework: Partial<FrameworkEntity>): Promise<FrameworkEntity>;
+  updateFramework(id: string, data: Partial<FrameworkEntity>): Promise<FrameworkEntity | null>;
+  deleteFramework(id: string): Promise<void>;
+  importFrameworks(frameworks: FrameworkEntity[]): Promise<void>;
 
   // System
   clearAllData(): Promise<void>;

--- a/server/db/postgres.ts
+++ b/server/db/postgres.ts
@@ -12,6 +12,8 @@ import type {
   CircleNodeType,
   CircleNodeModifier,
   ReminderEntity,
+  FrameworkEntity,
+  FrameworkType,
   MonthlyBalanceData
 } from '../../src/lib/persistence-types.js';
 
@@ -83,6 +85,16 @@ interface ReminderDbRow {
   snoozeDurationMinutes: number | null;
   originalTriggerDate: string | null;
   state: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+interface FrameworkDbRow {
+  id: string;
+  name: string;
+  frameworkType: string;
+  parentId: string | null;
+  categories: string;
   createdAt: string;
   updatedAt: string;
 }
@@ -304,6 +316,20 @@ class PostgresClient implements DbClient {
       )
     `);
 
+    // Frameworks table
+    await this.pool.query(`
+      CREATE TABLE IF NOT EXISTS "frameworks" (
+        "id" TEXT PRIMARY KEY,
+        "name" TEXT NOT NULL,
+        "frameworkType" TEXT NOT NULL CHECK ("frameworkType" IN ('intentional', 'collaborative')),
+        "parentId" TEXT,
+        "categories" JSONB NOT NULL DEFAULT '[]',
+        "createdAt" TIMESTAMP WITH TIME ZONE NOT NULL,
+        "updatedAt" TIMESTAMP WITH TIME ZONE NOT NULL,
+        CONSTRAINT "fk_frameworks_parent" FOREIGN KEY ("parentId") REFERENCES "frameworks" ("id") DEFERRABLE INITIALLY DEFERRED
+      )
+    `);
+
     // Create indexes for performance optimization
     // These indexes dramatically improve query performance when filtering by userId, parentId, or triageStatus
     await this.pool.query(`CREATE INDEX IF NOT EXISTS "idx_tasks_userId" ON "tasks"("userId")`);
@@ -323,6 +349,10 @@ class PostgresClient implements DbClient {
     await this.pool.query(`CREATE INDEX IF NOT EXISTS "idx_reminders_taskId" ON "reminders"("taskId")`);
     await this.pool.query(`CREATE INDEX IF NOT EXISTS "idx_reminders_state" ON "reminders"("state")`);
     await this.pool.query(`CREATE INDEX IF NOT EXISTS "idx_reminders_triggerDate" ON "reminders"("triggerDate")`);
+
+    // Frameworks indexes
+    await this.pool.query(`CREATE INDEX IF NOT EXISTS "idx_frameworks_frameworkType" ON "frameworks"("frameworkType")`);
+    await this.pool.query(`CREATE INDEX IF NOT EXISTS "idx_frameworks_parentId" ON "frameworks"("parentId")`);
 
     // 2. Run migrations AFTER tables exist
     try {
@@ -1290,6 +1320,126 @@ class PostgresClient implements DbClient {
     }
   }
 
+  // Frameworks
+  async getFrameworks(frameworkType?: string): Promise<FrameworkEntity[]> {
+    let sql = 'SELECT * FROM "frameworks"';
+    const params: string[] = [];
+    if (frameworkType) {
+      sql += ' WHERE "frameworkType" = $1';
+      params.push(frameworkType);
+    }
+    sql += ' ORDER BY "createdAt" ASC';
+    const result = await this.pool.query(sql, params);
+    return result.rows.map((row: FrameworkDbRow) => this.mapFrameworkDbRowToEntity(row));
+  }
+
+  async getFrameworkById(id: string): Promise<FrameworkEntity | null> {
+    const result = await this.pool.query('SELECT * FROM "frameworks" WHERE "id" = $1', [id]);
+    if (result.rows.length === 0) return null;
+    return this.mapFrameworkDbRowToEntity(result.rows[0]);
+  }
+
+  async createFramework(input: Partial<FrameworkEntity>): Promise<FrameworkEntity> {
+    const now = new Date().toISOString();
+    const newFramework: FrameworkEntity = {
+      id: input.id || crypto.randomUUID(),
+      name: input.name || 'New Framework',
+      frameworkType: input.frameworkType || 'intentional',
+      parentId: input.parentId ?? null,
+      categories: input.categories || [],
+      createdAt: input.createdAt || now,
+      updatedAt: input.updatedAt || now,
+    };
+
+    await this.pool.query(`
+      INSERT INTO "frameworks"("id", "name", "frameworkType", "parentId", "categories", "createdAt", "updatedAt")
+      VALUES($1, $2, $3, $4, $5, $6, $7)
+    `, [
+      newFramework.id,
+      newFramework.name,
+      newFramework.frameworkType,
+      newFramework.parentId,
+      JSON.stringify(newFramework.categories),
+      newFramework.createdAt,
+      newFramework.updatedAt,
+    ]);
+
+    return newFramework;
+  }
+
+  async updateFramework(id: string, patch: Partial<FrameworkEntity>): Promise<FrameworkEntity | null> {
+    const current = await this.getFrameworkById(id);
+    if (!current) return null;
+
+    const updated = { ...current, ...patch, updatedAt: new Date().toISOString() };
+
+    await this.pool.query(`
+      UPDATE "frameworks" SET
+        "name" = $1, "frameworkType" = $2, "parentId" = $3, "categories" = $4, "updatedAt" = $5
+      WHERE "id" = $6
+    `, [
+      updated.name,
+      updated.frameworkType,
+      updated.parentId,
+      JSON.stringify(updated.categories),
+      updated.updatedAt,
+      updated.id,
+    ]);
+
+    return updated;
+  }
+
+  async deleteFramework(id: string): Promise<void> {
+    await this.pool.query('DELETE FROM "frameworks" WHERE "id" = $1', [id]);
+  }
+
+  async importFrameworks(frameworks: FrameworkEntity[]): Promise<void> {
+    const client = await this.pool.connect();
+    try {
+      await client.query('BEGIN');
+
+      for (const framework of frameworks) {
+        await client.query(`
+          INSERT INTO "frameworks"("id", "name", "frameworkType", "parentId", "categories", "createdAt", "updatedAt")
+          VALUES($1, $2, $3, $4, $5, $6, $7)
+          ON CONFLICT ("id") DO UPDATE SET
+            "name" = EXCLUDED."name",
+            "frameworkType" = EXCLUDED."frameworkType",
+            "parentId" = EXCLUDED."parentId",
+            "categories" = EXCLUDED."categories",
+            "updatedAt" = EXCLUDED."updatedAt"
+        `, [
+          framework.id,
+          framework.name,
+          framework.frameworkType,
+          framework.parentId,
+          JSON.stringify(framework.categories),
+          framework.createdAt,
+          framework.updatedAt,
+        ]);
+      }
+
+      await client.query('COMMIT');
+    } catch (error) {
+      await client.query('ROLLBACK');
+      throw error;
+    } finally {
+      client.release();
+    }
+  }
+
+  private mapFrameworkDbRowToEntity(row: FrameworkDbRow): FrameworkEntity {
+    return {
+      id: row.id,
+      name: row.name,
+      frameworkType: row.frameworkType as FrameworkType,
+      parentId: row.parentId,
+      categories: typeof row.categories === 'string' ? JSON.parse(row.categories) : (row.categories || []),
+      createdAt: row.createdAt,
+      updatedAt: row.updatedAt,
+    };
+  }
+
   private mapTaskDbRowToEntity(row: TaskDbRow): TaskEntity {
     return {
       ...row,
@@ -1363,6 +1513,7 @@ class PostgresClient implements DbClient {
       await client.query('DROP TABLE IF EXISTS "dreamBoard" CASCADE');
       await client.query('DROP TABLE IF EXISTS "circles" CASCADE');
       await client.query('DROP TABLE IF EXISTS "reminders" CASCADE');
+      await client.query('DROP TABLE IF EXISTS "frameworks" CASCADE');
 
       // Drop legacy tables if they exist
       await client.query('DROP TABLE IF EXISTS tasks CASCADE');

--- a/server/db/sqlite.ts
+++ b/server/db/sqlite.ts
@@ -11,7 +11,9 @@ import type {
   CircleEntity,
   CircleNodeType,
   CircleNodeModifier,
-  ReminderEntity
+  ReminderEntity,
+  FrameworkEntity,
+  FrameworkType
 } from '../../src/lib/persistence-types.js';
 
 // Raw database row types (SQLite stores booleans as 0/1 integers and JSON as strings)
@@ -102,6 +104,16 @@ interface ReminderDbRow {
   snoozeDurationMinutes: number | null;
   originalTriggerDate: string | null;
   state: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+interface FrameworkDbRow {
+  id: string;
+  name: string;
+  frameworkType: string;
+  parentId: string | null;
+  categories: string;
   createdAt: string;
   updatedAt: string;
 }
@@ -320,6 +332,20 @@ class SqliteClient implements DbClient {
       )
     `);
 
+    // Frameworks table (intentional & collaborative frameworks)
+    this.db.exec(`
+      CREATE TABLE IF NOT EXISTS "frameworks" (
+        "id" TEXT PRIMARY KEY,
+        "name" TEXT NOT NULL,
+        "frameworkType" TEXT NOT NULL CHECK("frameworkType" IN ('intentional', 'collaborative')),
+        "parentId" TEXT,
+        "categories" TEXT NOT NULL DEFAULT '[]',
+        "createdAt" TEXT NOT NULL,
+        "updatedAt" TEXT NOT NULL,
+        FOREIGN KEY("parentId") REFERENCES "frameworks"("id")
+      )
+    `);
+
     // Create indexes for performance optimization
     // These indexes dramatically improve query performance when filtering by userId, parentId, or triageStatus
     this.db.exec(`CREATE INDEX IF NOT EXISTS "idx_tasks_userId" ON "tasks"("userId")`);
@@ -333,6 +359,10 @@ class SqliteClient implements DbClient {
     // Circles indexes
     this.db.exec(`CREATE INDEX IF NOT EXISTS "idx_circles_parentId" ON "circles"("parentId")`);
     this.db.exec(`CREATE INDEX IF NOT EXISTS "idx_circles_nodeType" ON "circles"("nodeType")`);
+
+    // Frameworks indexes
+    this.db.exec(`CREATE INDEX IF NOT EXISTS "idx_frameworks_frameworkType" ON "frameworks"("frameworkType")`);
+    this.db.exec(`CREATE INDEX IF NOT EXISTS "idx_frameworks_parentId" ON "frameworks"("parentId")`);
 
     // Reminders indexes
     this.db.exec(`CREATE INDEX IF NOT EXISTS "idx_reminders_userId" ON "reminders"("userId")`);
@@ -1410,6 +1440,127 @@ class SqliteClient implements DbClient {
     }
   }
 
+  // Frameworks
+  async getFrameworks(frameworkType?: string): Promise<FrameworkEntity[]> {
+    let sql = 'SELECT * FROM "frameworks"';
+    const params: string[] = [];
+    if (frameworkType) {
+      sql += ' WHERE "frameworkType" = ?';
+      params.push(frameworkType);
+    }
+    sql += ' ORDER BY "createdAt" ASC';
+    const rows = this.db.prepare(sql).all(...params) as unknown as FrameworkDbRow[];
+    return rows.map(row => this.mapFrameworkDbRowToEntity(row));
+  }
+
+  async getFrameworkById(id: string): Promise<FrameworkEntity | null> {
+    const row = this.db.prepare('SELECT * FROM "frameworks" WHERE "id" = ?').get(id) as unknown as FrameworkDbRow | undefined;
+    if (!row) return null;
+    return this.mapFrameworkDbRowToEntity(row);
+  }
+
+  async createFramework(input: Partial<FrameworkEntity>): Promise<FrameworkEntity> {
+    const now = new Date().toISOString();
+    const newFramework: FrameworkEntity = {
+      id: input.id || crypto.randomUUID(),
+      name: input.name || 'New Framework',
+      frameworkType: input.frameworkType || 'intentional',
+      parentId: input.parentId ?? null,
+      categories: input.categories || [],
+      createdAt: input.createdAt || now,
+      updatedAt: input.updatedAt || now,
+    };
+
+    this.db.prepare(`
+      INSERT INTO "frameworks"("id", "name", "frameworkType", "parentId", "categories", "createdAt", "updatedAt")
+      VALUES(@id, @name, @frameworkType, @parentId, @categories, @createdAt, @updatedAt)
+    `).run({
+      id: newFramework.id,
+      name: newFramework.name,
+      frameworkType: newFramework.frameworkType,
+      parentId: newFramework.parentId,
+      categories: JSON.stringify(newFramework.categories),
+      createdAt: newFramework.createdAt,
+      updatedAt: newFramework.updatedAt,
+    });
+
+    return newFramework;
+  }
+
+  async updateFramework(id: string, patch: Partial<FrameworkEntity>): Promise<FrameworkEntity | null> {
+    const current = await this.getFrameworkById(id);
+    if (!current) return null;
+
+    const updated = { ...current, ...patch, updatedAt: new Date().toISOString() };
+
+    this.db.prepare(`
+      UPDATE "frameworks" SET
+        "name" = @name,
+        "frameworkType" = @frameworkType,
+        "parentId" = @parentId,
+        "categories" = @categories,
+        "updatedAt" = @updatedAt
+      WHERE "id" = @id
+    `).run({
+      id: updated.id,
+      name: updated.name,
+      frameworkType: updated.frameworkType,
+      parentId: updated.parentId,
+      categories: JSON.stringify(updated.categories),
+      updatedAt: updated.updatedAt,
+    });
+
+    return updated;
+  }
+
+  async deleteFramework(id: string): Promise<void> {
+    this.db.prepare('DELETE FROM "frameworks" WHERE "id" = ?').run(id);
+  }
+
+  async importFrameworks(frameworks: FrameworkEntity[]): Promise<void> {
+    const insertStmt = this.db.prepare(`
+      INSERT INTO "frameworks"("id", "name", "frameworkType", "parentId", "categories", "createdAt", "updatedAt")
+      VALUES(@id, @name, @frameworkType, @parentId, @categories, @createdAt, @updatedAt)
+      ON CONFLICT("id") DO UPDATE SET
+        "name" = excluded."name",
+        "frameworkType" = excluded."frameworkType",
+        "parentId" = excluded."parentId",
+        "categories" = excluded."categories",
+        "updatedAt" = excluded."updatedAt"
+    `);
+
+    this.db.exec('BEGIN');
+    try {
+      for (const framework of frameworks) {
+        insertStmt.run({
+          id: framework.id,
+          name: framework.name,
+          frameworkType: framework.frameworkType,
+          parentId: framework.parentId,
+          categories: JSON.stringify(framework.categories),
+          createdAt: framework.createdAt,
+          updatedAt: framework.updatedAt,
+        });
+      }
+      this.db.exec('COMMIT');
+    } catch (error) {
+      this.db.exec('ROLLBACK');
+      throw error;
+    }
+  }
+
+  private mapFrameworkDbRowToEntity(row: FrameworkDbRow): FrameworkEntity {
+    return {
+      id: row.id,
+      name: row.name,
+      frameworkType: row.frameworkType as FrameworkType,
+      parentId: row.parentId,
+      categories: JSON.parse(row.categories || '[]'),
+      createdAt: row.createdAt,
+      updatedAt: row.updatedAt,
+    };
+  }
+
   private mapCircleDbRowToEntity(row: CircleDbRow): CircleEntity {
     return {
       id: row.id,
@@ -1461,6 +1612,7 @@ class SqliteClient implements DbClient {
       this.db.exec('DROP TABLE IF EXISTS "dreamBoard"');
       this.db.exec('DROP TABLE IF EXISTS "circles"');
       this.db.exec('DROP TABLE IF EXISTS "reminders"');
+      this.db.exec('DROP TABLE IF EXISTS "frameworks"');
 
       // Also drop legacy tables if they exist
       this.db.exec('DROP TABLE IF EXISTS tasks');

--- a/server/index.ts
+++ b/server/index.ts
@@ -509,6 +509,84 @@ app.post('/api/circles/import', express.json({ limit: '10mb' }), async (req: Req
   }
 });
 
+// Frameworks routes
+app.get('/api/frameworks', async (req: Request, res: Response) => {
+  try {
+    const frameworkType = req.query.frameworkType as string | undefined;
+    const frameworks = await db.getFrameworks(frameworkType);
+    res.json(frameworks);
+  } catch (error: unknown) {
+    console.error('Error fetching frameworks:', error);
+    const message = error instanceof Error ? error.message : String(error);
+    res.status(500).json({ error: 'Failed to fetch frameworks', details: message });
+  }
+});
+
+app.post('/api/frameworks', async (req: Request, res: Response) => {
+  try {
+    const framework = await db.createFramework(req.body);
+    res.status(201).json(framework);
+  } catch (error: unknown) {
+    console.error('Error creating framework:', error);
+    const message = error instanceof Error ? error.message : String(error);
+    res.status(500).json({ error: 'Failed to create framework', details: message });
+  }
+});
+
+app.get('/api/frameworks/:id', async (req: Request, res: Response) => {
+  try {
+    const framework = await db.getFrameworkById(req.params.id);
+    if (!framework) {
+      return res.status(404).json({ error: 'Framework not found' });
+    }
+    res.json(framework);
+  } catch (error: unknown) {
+    console.error('Error fetching framework:', error);
+    const message = error instanceof Error ? error.message : String(error);
+    res.status(500).json({ error: 'Failed to fetch framework', details: message });
+  }
+});
+
+app.patch('/api/frameworks/:id', async (req: Request, res: Response) => {
+  try {
+    const framework = await db.updateFramework(req.params.id, req.body);
+    if (!framework) {
+      return res.status(404).json({ error: 'Framework not found' });
+    }
+    res.json(framework);
+  } catch (error: unknown) {
+    console.error('Error updating framework:', error);
+    const message = error instanceof Error ? error.message : String(error);
+    res.status(500).json({ error: 'Failed to update framework', details: message });
+  }
+});
+
+app.delete('/api/frameworks/:id', async (req: Request, res: Response) => {
+  try {
+    await db.deleteFramework(req.params.id);
+    res.status(204).send();
+  } catch (error: unknown) {
+    console.error('Error deleting framework:', error);
+    const message = error instanceof Error ? error.message : String(error);
+    res.status(500).json({ error: 'Failed to delete framework', details: message });
+  }
+});
+
+app.post('/api/frameworks/import', express.json({ limit: '10mb' }), async (req: Request, res: Response) => {
+  try {
+    const frameworks = req.body;
+    if (!Array.isArray(frameworks)) {
+      return res.status(400).json({ error: 'Expected an array of frameworks' });
+    }
+    await db.importFrameworks(frameworks);
+    res.json({ ok: true });
+  } catch (error: unknown) {
+    console.error('Failed to import frameworks:', error);
+    const message = error instanceof Error ? error.message : String(error);
+    res.status(500).json({ error: 'Failed to import frameworks', details: message });
+  }
+});
+
 // Reminders routes
 app.get('/api/reminders', async (req: Request, res: Response) => {
   try {

--- a/src/components/CollaborativeFrameworkView.tsx
+++ b/src/components/CollaborativeFrameworkView.tsx
@@ -1,0 +1,136 @@
+import React, { useState, useEffect, useCallback } from 'react';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { FrameworkCategoryView } from '@/components/FrameworkCategoryView';
+import { useFrameworks } from '@/hooks/useFrameworks';
+import { FrameworkEntity, FrameworkCategory } from '@/lib/persistence-types';
+import { FocusModeProvider } from '@/components/FocusModeProvider';
+import { FocusModeOverlay } from '@/components/FocusModeOverlay';
+import { FocusModeBar } from '@/components/planView/FocusModeBar';
+import { useFocusMode } from '@/hooks/useFocusMode';
+import { Plus } from 'lucide-react';
+
+const COLLABORATIVE_CATEGORIES: Omit<FrameworkCategory, 'content' | 'order'>[] = [
+  { id: 'collaborative-values', label: 'Collaborative Values & Principles', description: 'The values important for efficient and pleasant collaboration and the principles that translate these values into action within the organization.' },
+  { id: 'expected-behaviors', label: 'Expected Behaviors', description: 'Behaviors to encourage, indispensable ones, to avoid, or unacceptable for efficient and pleasant collaboration.' },
+  { id: 'regular-meetings', label: 'Regular Meetings', description: 'The types of meetings practiced, their frequency and duration.' },
+  { id: 'entry-process', label: 'Entry Process', description: 'How a person can join the organization.' },
+  { id: 'exit-process', label: 'Exit Process', description: 'How a person can leave the organization.' },
+  { id: 'conflict-resolution', label: 'Conflict Resolution Process', description: 'How to constructively regulate tensions and conflicts between members.' },
+  { id: 'exclusion-process', label: 'Exclusion Process', description: 'How to separate from a person harming the organization or its members.' },
+  { id: 'collaborative-methods', label: 'Collaborative Methods', description: 'Project management methods used in complement to this constitution.', optional: true },
+  { id: 'individual-support', label: 'Individual Support Process', description: 'How to offer personal support.', optional: true },
+  { id: 'peer-support', label: 'Peer Support Process', description: 'How to help each other and learn together.', optional: true },
+];
+
+interface CollaborativeFrameworkViewProps {
+  onFocusOnTask?: (taskId: string) => void;
+  hideHeader?: boolean;
+}
+
+const CollaborativeFrameworkViewInner: React.FC<CollaborativeFrameworkViewProps> = ({ hideHeader }) => {
+  const { frameworks, createFramework, updateFramework } = useFrameworks('collaborative');
+  const { isFocusMode } = useFocusMode();
+  const [framework, setFramework] = useState<FrameworkEntity | null>(null);
+
+  useEffect(() => {
+    if (frameworks.length > 0) {
+      setFramework(frameworks[0]);
+    }
+  }, [frameworks]);
+
+  const handleCreateFramework = useCallback(async () => {
+    const categories: FrameworkCategory[] = COLLABORATIVE_CATEGORIES.map((cat, idx) => ({
+      ...cat,
+      content: '',
+      order: idx,
+    }));
+    const created = await createFramework({
+      name: 'Collaborative Framework',
+      frameworkType: 'collaborative',
+      categories,
+    });
+    if (created) setFramework(created);
+  }, [createFramework]);
+
+  const handleCategoryChange = useCallback((categoryId: string, content: string) => {
+    if (!framework) return;
+    const updatedCategories = framework.categories.map(cat =>
+      cat.id === categoryId ? { ...cat, content } : cat
+    );
+    const updated = { ...framework, categories: updatedCategories, updatedAt: new Date().toISOString() };
+    setFramework(updated);
+    updateFramework(framework.id, { categories: updatedCategories });
+  }, [framework, updateFramework]);
+
+  const viewTitle = 'Collaborative Framework';
+
+  if (!framework) {
+    return (
+      <div className={`h-full flex flex-col ${isFocusMode && !hideHeader ? 'relative' : ''}`}>
+        {!hideHeader && isFocusMode && <FocusModeBar title={viewTitle} />}
+        <Card className="flex-1 flex flex-col min-h-0 border-0 shadow-none">
+          {!hideHeader && !isFocusMode && (
+            <CardHeader className="flex flex-col space-y-4 pb-2 shrink-0">
+              <div className="flex flex-row items-center justify-between">
+                <CardTitle>Collaborative Framework</CardTitle>
+              </div>
+            </CardHeader>
+          )}
+          <CardContent className="flex-1 min-h-0 overflow-auto">
+            <div className="flex flex-col items-center justify-center h-full text-gray-500">
+              <p className="mb-4">No collaborative framework created yet.</p>
+              <Button onClick={handleCreateFramework}>
+                <Plus className="w-4 h-4 mr-2" /> Create Collaborative Framework
+              </Button>
+            </div>
+          </CardContent>
+        </Card>
+      </div>
+    );
+  }
+
+  return (
+    <div className={`h-full flex flex-col ${isFocusMode && !hideHeader ? 'relative' : ''}`}>
+      {!hideHeader && isFocusMode && <FocusModeBar title={viewTitle} />}
+      <Card className={`flex-1 flex flex-col min-h-0 border-0 shadow-none ${isFocusMode && !hideHeader ? 'overflow-auto' : ''}`}>
+        {!hideHeader && !isFocusMode && (
+          <CardHeader className="flex flex-col space-y-4 pb-2 shrink-0">
+            <div className="flex flex-row items-center justify-between">
+              <CardTitle>Collaborative Framework</CardTitle>
+            </div>
+          </CardHeader>
+        )}
+        <CardContent className="flex-1 min-h-0 overflow-auto px-6 py-4">
+          {framework.categories
+            .sort((a, b) => a.order - b.order)
+            .map(category => (
+              <FrameworkCategoryView
+                key={category.id}
+                categoryId={category.id}
+                label={category.label}
+                description={category.description}
+                content={category.content}
+                onChange={(content) => handleCategoryChange(category.id, content)}
+                frameworkId={framework.id}
+                optional={category.optional}
+              />
+            ))}
+        </CardContent>
+      </Card>
+    </div>
+  );
+};
+
+const CollaborativeFrameworkView: React.FC<CollaborativeFrameworkViewProps> = (props) => {
+  return (
+    <FocusModeProvider viewId="collaborativeFramework">
+      <FocusModeOverlay>
+        <CollaborativeFrameworkViewInner {...props} />
+      </FocusModeOverlay>
+    </FocusModeProvider>
+  );
+};
+
+export { CollaborativeFrameworkViewInner };
+export default CollaborativeFrameworkView;

--- a/src/components/DataExporter.tsx
+++ b/src/components/DataExporter.tsx
@@ -46,6 +46,9 @@ const DataExporter: React.FC = () => {
         timezone: appSettings.timezone,
         country: appSettings.country,
         region: appSettings.region,
+        splitTime: appSettings.splitTime?.toString(),
+        cardAgingBaseDays: appSettings.cardAgingBaseDays?.toString(),
+        disabledModules: appSettings.disabledModules,
       };
 
       // Fetch Fertilization Board state
@@ -60,6 +63,9 @@ const DataExporter: React.FC = () => {
       // Fetch ALL circles
       const allCircles = await adapter.listCircles();
 
+      // Fetch ALL frameworks
+      const allFrameworks = await adapter.listFrameworks();
+
       const exportData = {
         tasks: allTasks,
         scheduledReminders: allReminders, // Unified export using persistence layer
@@ -67,6 +73,7 @@ const DataExporter: React.FC = () => {
         fertilizationBoard: fertilizationBoardState, // Export Fertilization Board state
         dreamBoard: dreamBoardState, // Export Dream Board state
         circles: allCircles, // Export Circles
+        frameworks: allFrameworks, // Export Frameworks
         settings: settingsToExport,
         activeUserId: userId,
         allUserSettings, // Export all users for full restore

--- a/src/components/DataImporter.tsx
+++ b/src/components/DataImporter.tsx
@@ -5,7 +5,7 @@ import { Input } from '@/components/ui/input';
 import { useReminderStore } from '@/hooks/useReminders';
 import { getPersistenceAdapter } from '@/lib/persistence-factory';
 import { QolSurveyResponseEntity, MonthlyBalanceData } from '@/lib/persistence-types';
-import { yUserSettings, yFertilizationState, yFertilizationCards, yFertilizationColumns, yDreamState, yDreamCards, yDreamColumns, yCircles, isCollaborationEnabled, doc } from '@/lib/collaboration';
+import { yUserSettings, yFertilizationState, yFertilizationCards, yFertilizationColumns, yDreamState, yDreamCards, yDreamColumns, yCircles, yFrameworks, yAppSettings, isCollaborationEnabled, doc } from '@/lib/collaboration';
 
 interface ImportedUserSettings {
   userId?: string;
@@ -143,8 +143,21 @@ const DataImporter: React.FC = () => {
                   timezone: importedData.settings.timezone,
                   country: importedData.settings.country,
                   region: importedData.settings.region,
+                  splitTime: importedData.settings.splitTime ? Number(importedData.settings.splitTime) : undefined,
+                  cardAgingBaseDays: importedData.settings.cardAgingBaseDays ? Number(importedData.settings.cardAgingBaseDays) : undefined,
+                  disabledModules: importedData.settings.disabledModules || undefined,
                 };
                 await adapter.updateAppSettings(appSettings);
+                // Sync to Yjs for cross-client synchronization
+                if (isCollaborationEnabled()) {
+                  doc.transact(() => {
+                    for (const [key, value] of Object.entries(appSettings)) {
+                      if (value !== undefined) {
+                        yAppSettings.set(key, JSON.stringify(value));
+                      }
+                    }
+                  });
+                }
               }
 
               // Import Fertilization Board (or legacy Celebration Board)
@@ -249,6 +262,20 @@ const DataImporter: React.FC = () => {
                     yCircles.clear();
                     importedData.circles.forEach((circle: { id: string; [key: string]: unknown }) => {
                       yCircles.set(circle.id, circle);
+                    });
+                  });
+                }
+              }
+
+              // Import Frameworks (bulk)
+              if (importedData.frameworks && Array.isArray(importedData.frameworks)) {
+                await adapter.importFrameworks(importedData.frameworks);
+                // Sync to Yjs for cross-client synchronization
+                if (isCollaborationEnabled()) {
+                  doc.transact(() => {
+                    yFrameworks.clear();
+                    importedData.frameworks.forEach((framework: { id: string; [key: string]: unknown }) => {
+                      yFrameworks.set(framework.id, framework);
                     });
                   });
                 }

--- a/src/components/DreamTopView.tsx
+++ b/src/components/DreamTopView.tsx
@@ -18,6 +18,8 @@ import { ChevronDown, ChevronRight } from "lucide-react";
 import { FocusModeProvider } from "./FocusModeProvider";
 import { FocusModeOverlay } from "./FocusModeOverlay";
 import { FocusModeBar } from './planView/FocusModeBar';
+import { IntentionalFrameworkViewInner } from './IntentionalFrameworkView';
+import { CollaborativeFrameworkViewInner } from './CollaborativeFrameworkView';
 import { useFocusMode } from "@/hooks/useFocusMode";
 import type { ModuleId } from '@/lib/persistence-types';
 
@@ -25,10 +27,26 @@ interface DreamTopViewProps {
   onFocusOnTask: (taskId: string) => void;
 }
 
-type ActiveView = 'dream' | 'storyboard' | 'prioritization';
+type ActiveView = 'intentionalFramework' | 'collaborativeFramework' | 'dream' | 'storyboard' | 'prioritization';
 
 const ViewToggleButtons: React.FC<{ activeView: ActiveView; setActiveView: (v: ActiveView) => void; enabledSubViews: ActiveView[] }> = React.memo(({ activeView, setActiveView, enabledSubViews }) => (
   <div className="flex space-x-2">
+    {enabledSubViews.includes('intentionalFramework') && (
+    <Button
+      variant={activeView === 'intentionalFramework' ? 'default' : 'outline'}
+      onClick={() => setActiveView('intentionalFramework')}
+    >
+      Intention
+    </Button>
+    )}
+    {enabledSubViews.includes('collaborativeFramework') && (
+    <Button
+      variant={activeView === 'collaborativeFramework' ? 'default' : 'outline'}
+      onClick={() => setActiveView('collaborativeFramework')}
+    >
+      Collaboration
+    </Button>
+    )}
     {enabledSubViews.includes('dream') && (
     <Button
       variant={activeView === 'dream' ? 'default' : 'outline'}
@@ -37,20 +55,20 @@ const ViewToggleButtons: React.FC<{ activeView: ActiveView; setActiveView: (v: A
       Dream
     </Button>
     )}
-    {enabledSubViews.includes('prioritization') && (
-    <Button
-      variant={activeView === 'prioritization' ? 'default' : 'outline'}
-      onClick={() => setActiveView('prioritization')}
-    >
-      Prioritization
-    </Button>
-    )}
     {enabledSubViews.includes('storyboard') && (
     <Button
       variant={activeView === 'storyboard' ? 'default' : 'outline'}
       onClick={() => setActiveView('storyboard')}
     >
       Storyboard
+    </Button>
+    )}
+    {enabledSubViews.includes('prioritization') && (
+    <Button
+      variant={activeView === 'prioritization' ? 'default' : 'outline'}
+      onClick={() => setActiveView('prioritization')}
+    >
+      Prioritization
     </Button>
     )}
   </div>
@@ -64,7 +82,7 @@ const DreamTopViewInner: React.FC<DreamTopViewProps> = ({ onFocusOnTask }) => {
   const { userId: currentUserId } = useUserSettings();
   const { isFocusMode } = useFocusMode();
 
-  const enabledSubViews: ActiveView[] = (['dream', 'storyboard', 'prioritization'] as ActiveView[]).filter(
+  const enabledSubViews: ActiveView[] = (['intentionalFramework', 'collaborativeFramework', 'dream', 'storyboard', 'prioritization'] as ActiveView[]).filter(
     v => !disabledModules.includes(`dream.${v}` as ModuleId)
   );
 
@@ -127,7 +145,7 @@ const DreamTopViewInner: React.FC<DreamTopViewProps> = ({ onFocusOnTask }) => {
   // Consume pending sub-view from Umbrella navigation
   useEffect(() => {
     if (!pendingSubView) return;
-    const valid: ActiveView[] = ['dream', 'storyboard', 'prioritization'];
+    const valid: ActiveView[] = ['intentionalFramework', 'collaborativeFramework', 'dream', 'storyboard', 'prioritization'];
     if (valid.includes(pendingSubView as ActiveView) && enabledSubViews.includes(pendingSubView as ActiveView)) {
       setActiveView(pendingSubView as ActiveView);
       clearPendingSubView();
@@ -309,6 +327,52 @@ const DreamTopViewInner: React.FC<DreamTopViewProps> = ({ onFocusOnTask }) => {
               onPromoteToKanban={handlePromoteToKanban}
               focusModeHeaderContent={isFocusMode ? <ViewToggleButtons activeView={activeView} setActiveView={setActiveView} enabledSubViews={enabledSubViews} /> : undefined}
             />
+          </CardContent>
+        </Card>
+      </div>
+    );
+  }
+
+  // Render Intentional Framework sub-view
+  if (activeView === 'intentionalFramework') {
+    const viewTitle = 'Intentional Framework';
+    return (
+      <div className={`h-full flex flex-col ${isFocusMode ? 'relative' : ''}`}>
+        {isFocusMode && <FocusModeBar title={viewTitle} rightContent={<ViewToggleButtons activeView={activeView} setActiveView={setActiveView} enabledSubViews={enabledSubViews} />} />}
+        <Card className={`flex-1 flex flex-col border-0 shadow-none ${isFocusMode ? 'overflow-auto' : ''}`}>
+          {!isFocusMode && (
+            <CardHeader className="flex flex-col space-y-4 pb-2">
+              <div className="flex flex-row items-center justify-between">
+                <CardTitle>{viewTitle}</CardTitle>
+                <ViewToggleButtons activeView={activeView} setActiveView={setActiveView} enabledSubViews={enabledSubViews} />
+              </div>
+            </CardHeader>
+          )}
+          <CardContent className="flex-grow overflow-auto">
+            <IntentionalFrameworkViewInner hideHeader />
+          </CardContent>
+        </Card>
+      </div>
+    );
+  }
+
+  // Render Collaborative Framework sub-view
+  if (activeView === 'collaborativeFramework') {
+    const viewTitle = 'Collaborative Framework';
+    return (
+      <div className={`h-full flex flex-col ${isFocusMode ? 'relative' : ''}`}>
+        {isFocusMode && <FocusModeBar title={viewTitle} rightContent={<ViewToggleButtons activeView={activeView} setActiveView={setActiveView} enabledSubViews={enabledSubViews} />} />}
+        <Card className={`flex-1 flex flex-col border-0 shadow-none ${isFocusMode ? 'overflow-auto' : ''}`}>
+          {!isFocusMode && (
+            <CardHeader className="flex flex-col space-y-4 pb-2">
+              <div className="flex flex-row items-center justify-between">
+                <CardTitle>{viewTitle}</CardTitle>
+                <ViewToggleButtons activeView={activeView} setActiveView={setActiveView} enabledSubViews={enabledSubViews} />
+              </div>
+            </CardHeader>
+          )}
+          <CardContent className="flex-grow overflow-auto">
+            <CollaborativeFrameworkViewInner hideHeader />
           </CardContent>
         </Card>
       </div>

--- a/src/components/FrameworkCategoryView.tsx
+++ b/src/components/FrameworkCategoryView.tsx
@@ -1,0 +1,193 @@
+import * as React from "react";
+import { useCreateBlockNote } from "@blocknote/react";
+import { BlockNoteView } from "@blocknote/mantine";
+import "@blocknote/mantine/style.css";
+import { doc, isCollaborationEnabled, provider } from "@/lib/collaboration";
+import { useUserSettings } from "@/hooks/useUserSettings";
+
+const CURSOR_COLORS = [
+  "#f87171", "#fb923c", "#facc15", "#a3e635", "#4ade80",
+  "#2dd4bf", "#38bdf8", "#818cf8", "#c084fc", "#f472b6",
+];
+
+function getRandomColor(): string {
+  return CURSOR_COLORS[Math.floor(Math.random() * CURSOR_COLORS.length)];
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function deserializeBlocks(raw: string | undefined): any[] {
+  if (!raw || raw.trim() === "") {
+    return [{ type: "paragraph", content: [{ type: "text", text: "" }] }];
+  }
+  try {
+    const parsed = JSON.parse(raw);
+    if (Array.isArray(parsed) && parsed.length > 0) return parsed;
+  } catch {
+    // fall through
+  }
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const blocks: any[] = [];
+  for (const line of (raw || "").split("\n")) {
+    const trimmed = line.trimEnd();
+    if (!trimmed.trim()) continue;
+    if (trimmed.startsWith("* ") || trimmed.startsWith("- ")) {
+      blocks.push({
+        type: "bulletListItem",
+        content: [{ type: "text", text: trimmed.slice(2).trimStart() }],
+      });
+    } else {
+      blocks.push({
+        type: "paragraph",
+        content: [{ type: "text", text: trimmed }],
+      });
+    }
+  }
+  return blocks.length
+    ? blocks
+    : [{ type: "paragraph", content: [{ type: "text", text: "" }] }];
+}
+
+interface FrameworkCategoryViewProps {
+  categoryId: string;
+  label: string;
+  description: string;
+  content: string;
+  onChange: (json: string) => void;
+  frameworkId: string;
+  optional?: boolean;
+  collapsible?: boolean;
+}
+
+export const FrameworkCategoryView: React.FC<FrameworkCategoryViewProps> = ({
+  categoryId,
+  label,
+  description,
+  content,
+  onChange,
+  frameworkId,
+  optional = false,
+  collapsible = true,
+}) => {
+  const { userSettings } = useUserSettings();
+  const [userColor] = React.useState(getRandomColor);
+  const [isCollapsed, setIsCollapsed] = React.useState(false);
+
+  const collaborativeKey = `framework-${frameworkId}-${categoryId}`;
+  const initialBlocks = deserializeBlocks(content);
+
+  const editor = useCreateBlockNote(
+    collaborativeKey && isCollaborationEnabled()
+      ? {
+          collaboration: {
+            fragment: doc.getXmlFragment(collaborativeKey),
+            provider: provider || undefined,
+            user: {
+              name: userSettings.username || "Anonymous",
+              color: userColor,
+            },
+            showCursorLabels: "activity",
+          },
+          placeholders: { default: `Write your ${label.toLowerCase()} here...` },
+        }
+      : {
+          initialContent: initialBlocks,
+          placeholders: { default: `Write your ${label.toLowerCase()} here...` },
+        }
+  );
+
+  React.useEffect(() => {
+    if (!collaborativeKey || !isCollaborationEnabled()) return;
+    if (!editor) return;
+
+    const fragment = doc.getXmlFragment(collaborativeKey);
+    const isEmpty = fragment.length === 0;
+
+    if (isEmpty && initialBlocks.length > 0) {
+      const rafId = requestAnimationFrame(() => {
+        try {
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          editor.replaceBlocks(editor.document.map((b: any) => b.id), initialBlocks);
+        } catch {
+          // Editor might not be ready
+        }
+      });
+      return () => cancelAnimationFrame(rafId);
+    }
+  }, [collaborativeKey, editor, initialBlocks]);
+
+  // Handle content changes
+  React.useEffect(() => {
+    if (!editor) return;
+    let didInit = false;
+    const unsubscribe = editor.onChange(() => {
+      if (!didInit) {
+        didInit = true;
+        return;
+      }
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const json = JSON.stringify(editor.document.map((b: any) => ({
+        id: b.id,
+        type: b.type,
+        content: b.content,
+        children: b.children,
+        props: b.props,
+      })));
+      onChange(json);
+
+      if (collaborativeKey && isCollaborationEnabled()) {
+        const match = collaborativeKey.match(/^framework-([^-]+)-(.+)$/);
+        if (match) {
+          const [, fwId] = match;
+          doc.transact(() => {
+            const existing = yFrameworks.get(fwId);
+            if (existing && typeof existing === "object") {
+              yFrameworks.set(fwId, { ...existing });
+            }
+          });
+        }
+      }
+    });
+    return () => unsubscribe();
+  }, [editor, collaborativeKey, onChange]);
+
+  return (
+    <div className="border rounded-lg mb-4 bg-white">
+      <div
+        className="flex items-center justify-between px-4 py-3 cursor-pointer hover:bg-gray-50 select-none"
+        onClick={() => collapsible && setIsCollapsed(!isCollapsed)}
+      >
+        <div className="flex items-center gap-2 min-w-0">
+          <h3 className="text-base font-semibold text-gray-900 uppercase tracking-wide truncate">
+            {label}
+          </h3>
+          {optional && (
+            <span className="text-xs text-gray-400 italic shrink-0">(optional)</span>
+          )}
+        </div>
+        {collapsible && (
+          <span className="text-gray-400 text-sm shrink-0 ml-2">
+            {isCollapsed ? "▸" : "▾"}
+          </span>
+        )}
+      </div>
+
+      {!isCollapsed && (
+        <>
+          <div className="px-4 pb-2">
+            <p className="text-sm text-gray-500 italic">{description}</p>
+          </div>
+          <div className="px-4 pb-4">
+            <div className="min-h-[80px] rounded-md border border-gray-200 bg-white">
+              <BlockNoteView
+                // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                editor={editor as any}
+                theme="light"
+                className="w-full"
+              />
+            </div>
+          </div>
+        </>
+      )}
+    </div>
+  );
+};

--- a/src/components/IntentionalFrameworkView.tsx
+++ b/src/components/IntentionalFrameworkView.tsx
@@ -1,0 +1,136 @@
+import React, { useState, useEffect, useCallback } from 'react';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { FrameworkCategoryView } from '@/components/FrameworkCategoryView';
+import { useFrameworks } from '@/hooks/useFrameworks';
+import { FrameworkEntity, FrameworkCategory } from '@/lib/persistence-types';
+import { FocusModeProvider } from '@/components/FocusModeProvider';
+import { FocusModeOverlay } from '@/components/FocusModeOverlay';
+import { FocusModeBar } from '@/components/planView/FocusModeBar';
+import { useFocusMode } from '@/hooks/useFocusMode';
+import { Plus, ChevronDown, ChevronRight } from 'lucide-react';
+
+const INTENTIONAL_CATEGORIES: Omit<FrameworkCategory, 'content' | 'order'>[] = [
+  { id: 'mission', label: 'Mission', description: 'What do we concretely do, and for whom? What are our main product or service offerings, our value propositions?' },
+  { id: 'purpose', label: 'Purpose', description: 'Why, for whom, and for what do we do what we do? What effect are we seeking to produce by doing what we do? What is our main motivation for carrying out our mission(s)?' },
+  { id: 'values', label: 'Values & Principles', description: 'What are our values and their principles for practical application? Who or what truly matters to us? What way of acting allows us to translate our values into action?' },
+  { id: 'regenerative', label: 'Regenerative Aims', description: 'What positive contributions do we wish to make to natural and social systems? What results do we want to achieve, and in what timeframe?', optional: true },
+  { id: 'legal', label: 'Legal & Economic', description: 'Is a particular legal status important to us, and if so, which one? Is a particular economic model important to us, and if so, which one?', optional: true },
+  { id: 'ambition', label: 'Ambition', description: 'What are our concrete and measurable ambitions? What are our qualitative or quantitative ambitions? What results do we want to achieve? In what timeframe?', optional: true },
+  { id: 'temporality', label: 'Temporality', description: 'Is a particular timeframe important to us, and if so, which one?', optional: true },
+  { id: 'vision', label: 'Vision', description: 'What ideal world do we wish for? Why, for whom, or for what do we wish for this world?', optional: true },
+  { id: 'socialRoles', label: 'Social Roles', description: 'What role do we identify with to fulfill our mission(s)? What are our professions to offer our products or services?', optional: true },
+  { id: 'identity', label: 'Identity', description: 'Who do we identify as, as members of the organization? Symbolically, what is this identity like?', optional: true },
+];
+
+interface IntentionalFrameworkViewProps {
+  onFocusOnTask?: (taskId: string) => void;
+  hideHeader?: boolean;
+}
+
+const IntentionalFrameworkViewInner: React.FC<IntentionalFrameworkViewProps> = ({ hideHeader }) => {
+  const { frameworks, createFramework, updateFramework } = useFrameworks('intentional');
+  const { isFocusMode } = useFocusMode();
+  const [framework, setFramework] = useState<FrameworkEntity | null>(null);
+
+  useEffect(() => {
+    if (frameworks.length > 0) {
+      setFramework(frameworks[0]);
+    }
+  }, [frameworks]);
+
+  const handleCreateFramework = useCallback(async () => {
+    const categories: FrameworkCategory[] = INTENTIONAL_CATEGORIES.map((cat, idx) => ({
+      ...cat,
+      content: '',
+      order: idx,
+    }));
+    const created = await createFramework({
+      name: 'Intentional Framework',
+      frameworkType: 'intentional',
+      categories,
+    });
+    if (created) setFramework(created);
+  }, [createFramework]);
+
+  const handleCategoryChange = useCallback((categoryId: string, content: string) => {
+    if (!framework) return;
+    const updatedCategories = framework.categories.map(cat =>
+      cat.id === categoryId ? { ...cat, content } : cat
+    );
+    const updated = { ...framework, categories: updatedCategories, updatedAt: new Date().toISOString() };
+    setFramework(updated);
+    updateFramework(framework.id, { categories: updatedCategories });
+  }, [framework, updateFramework]);
+
+  const viewTitle = 'Intentional Framework';
+
+  if (!framework) {
+    return (
+      <div className={`h-full flex flex-col ${isFocusMode && !hideHeader ? 'relative' : ''}`}>
+        {!hideHeader && isFocusMode && <FocusModeBar title={viewTitle} />}
+        <Card className="flex-1 flex flex-col min-h-0 border-0 shadow-none">
+          {!hideHeader && !isFocusMode && (
+            <CardHeader className="flex flex-col space-y-4 pb-2 shrink-0">
+              <div className="flex flex-row items-center justify-between">
+                <CardTitle>Intentional Framework</CardTitle>
+              </div>
+            </CardHeader>
+          )}
+          <CardContent className="flex-1 min-h-0 overflow-auto">
+            <div className="flex flex-col items-center justify-center h-full text-gray-500">
+              <p className="mb-4">No intentional framework created yet.</p>
+              <Button onClick={handleCreateFramework}>
+                <Plus className="w-4 h-4 mr-2" /> Create Intentional Framework
+              </Button>
+            </div>
+          </CardContent>
+        </Card>
+      </div>
+    );
+  }
+
+  return (
+    <div className={`h-full flex flex-col ${isFocusMode && !hideHeader ? 'relative' : ''}`}>
+      {!hideHeader && isFocusMode && <FocusModeBar title={viewTitle} />}
+      <Card className={`flex-1 flex flex-col min-h-0 border-0 shadow-none ${isFocusMode && !hideHeader ? 'overflow-auto' : ''}`}>
+        {!hideHeader && !isFocusMode && (
+          <CardHeader className="flex flex-col space-y-4 pb-2 shrink-0">
+            <div className="flex flex-row items-center justify-between">
+              <CardTitle>Intentional Framework</CardTitle>
+            </div>
+          </CardHeader>
+        )}
+        <CardContent className="flex-1 min-h-0 overflow-auto px-6 py-4">
+          {framework.categories
+            .sort((a, b) => a.order - b.order)
+            .map(category => (
+              <FrameworkCategoryView
+                key={category.id}
+                categoryId={category.id}
+                label={category.label}
+                description={category.description}
+                content={category.content}
+                onChange={(content) => handleCategoryChange(category.id, content)}
+                frameworkId={framework.id}
+                optional={category.optional}
+              />
+            ))}
+        </CardContent>
+      </Card>
+    </div>
+  );
+};
+
+const IntentionalFrameworkView: React.FC<IntentionalFrameworkViewProps> = (props) => {
+  return (
+    <FocusModeProvider viewId="intentionalFramework">
+      <FocusModeOverlay>
+        <IntentionalFrameworkViewInner {...props} />
+      </FocusModeOverlay>
+    </FocusModeProvider>
+  );
+};
+
+export { IntentionalFrameworkViewInner };
+export default IntentionalFrameworkView;

--- a/src/components/UmbrellaNavigation.tsx
+++ b/src/components/UmbrellaNavigation.tsx
@@ -16,6 +16,7 @@ import {
   Calendar,
   Users,
   ShieldCheck,
+  Target,
 } from 'lucide-react';
 
 interface UmbrellaNavigationProps {
@@ -64,6 +65,8 @@ const SECTIONS: Section[] = [
     icon: <Sparkles className="w-5 h-5" />,
     position: 'bottom-left',
     views: [
+      { id: 'intentional-framework', label: 'Intention', icon: <Target className="w-3 h-3" />, view: 'dream', subView: 'intentionalFramework' },
+      { id: 'collaborative-framework', label: 'Collaboration', icon: <Users className="w-3 h-3" />, view: 'dream', subView: 'collaborativeFramework' },
       { id: 'dream-board', label: 'Dream Board', icon: <Sparkles className="w-3 h-3" />, view: 'dream', subView: 'dream' },
       { id: 'storyboard', label: 'Storyboard', icon: <LayoutDashboard className="w-3 h-3" />, view: 'dream', subView: 'storyboard' },
       { id: 'prioritization', label: 'Prioritization', icon: <ListChecks className="w-3 h-3" />, view: 'dream', subView: 'prioritization' },

--- a/src/hooks/useFrameworks.ts
+++ b/src/hooks/useFrameworks.ts
@@ -1,0 +1,240 @@
+import * as React from "react";
+import { eventBus } from "@/lib/events";
+import { FrameworkEntity, FrameworkType } from "@/lib/persistence-types";
+import { doc, isCollaborationEnabled, initializeCollaboration, yFrameworks } from "@/lib/collaboration";
+import { PERSISTENCE_CONFIG } from "@/lib/persistence-config";
+import { getPersistenceAdapter } from "@/lib/persistence-factory";
+
+let frameworks: FrameworkEntity[] = [];
+
+const syncFrameworksToYjs = () => {
+  if (!isCollaborationEnabled()) {
+    initializeCollaboration();
+  }
+  if (!isCollaborationEnabled()) return;
+  doc.transact(() => {
+    const currentIds = Array.from(yFrameworks.keys()) as string[];
+    const newIds = frameworks.map(f => f.id);
+    currentIds.forEach(id => {
+      if (!newIds.includes(id)) {
+        yFrameworks.delete(id);
+      }
+    });
+    frameworks.forEach(framework => {
+      const existing = yFrameworks.get(framework.id) as FrameworkEntity | undefined;
+      if (!existing || JSON.stringify(existing) !== JSON.stringify(framework)) {
+        yFrameworks.set(framework.id, framework);
+      }
+    });
+  });
+};
+
+const saveFrameworksToBrowser = async () => {
+  try {
+    const adapter = await getPersistenceAdapter();
+    await adapter.importFrameworks(frameworks);
+  } catch (error) {
+    console.error("Error saving frameworks to browser persistence:", error);
+  }
+};
+
+const loadFrameworks = async (frameworkType?: FrameworkType): Promise<FrameworkEntity[]> => {
+  try {
+    if (PERSISTENCE_CONFIG.FORCE_BROWSER) {
+      const adapter = await getPersistenceAdapter();
+      frameworks = await adapter.listFrameworks(frameworkType);
+      eventBus.publish("frameworksChanged");
+      return frameworks;
+    }
+
+    if (isCollaborationEnabled() && yFrameworks.size > 0) {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      frameworks = (Array.from(yFrameworks.values()) as any[]).map(v => {
+        if (v && typeof v.toJSON === "function") return v.toJSON();
+        return JSON.parse(JSON.stringify(v));
+      }) as FrameworkEntity[];
+      if (frameworkType) {
+        frameworks = frameworks.filter(f => f.frameworkType === frameworkType);
+      }
+      eventBus.publish("frameworksChanged");
+      return frameworks;
+    }
+
+    let url = "/api/frameworks";
+    if (frameworkType) {
+      url += `?frameworkType=${encodeURIComponent(frameworkType)}`;
+    }
+    const response = await fetch(url);
+    if (!response.ok) {
+      throw new Error(`Failed to load frameworks: ${response.statusText}`);
+    }
+    const data = await response.json();
+    frameworks = data;
+    eventBus.publish("frameworksChanged");
+    syncFrameworksToYjs();
+    return frameworks;
+  } catch (error) {
+    console.error("Error loading frameworks:", error);
+    return [];
+  }
+};
+
+const createFramework = async (input: Partial<FrameworkEntity>): Promise<FrameworkEntity | null> => {
+  try {
+    const now = new Date().toISOString();
+    const newFramework: FrameworkEntity = {
+      id: input.id || crypto.randomUUID(),
+      name: input.name || "New Framework",
+      frameworkType: input.frameworkType || "intentional",
+      parentId: input.parentId ?? null,
+      categories: input.categories || [],
+      createdAt: input.createdAt || now,
+      updatedAt: input.updatedAt || now,
+    };
+
+    if (PERSISTENCE_CONFIG.FORCE_BROWSER) {
+      frameworks = [...frameworks, newFramework];
+      eventBus.publish("frameworksChanged");
+      await saveFrameworksToBrowser();
+      return newFramework;
+    }
+
+    const response = await fetch("/api/frameworks", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(newFramework),
+    });
+    if (!response.ok) {
+      throw new Error(`Failed to create framework: ${response.statusText}`);
+    }
+    const created = await response.json();
+    frameworks = [...frameworks, created];
+    eventBus.publish("frameworksChanged");
+    syncFrameworksToYjs();
+    return created;
+  } catch (error) {
+    console.error("Error creating framework:", error);
+    return null;
+  }
+};
+
+const updateFramework = async (
+  id: string,
+  data: Partial<FrameworkEntity>
+): Promise<FrameworkEntity | null> => {
+  try {
+    if (PERSISTENCE_CONFIG.FORCE_BROWSER) {
+      const index = frameworks.findIndex(f => f.id === id);
+      if (index === -1) {
+        console.warn("Update framework: not found", id);
+        return null;
+      }
+      const updated = { ...frameworks[index], ...data, updatedAt: new Date().toISOString() };
+      frameworks = frameworks.map(f => (f.id === id ? updated : f));
+      eventBus.publish("frameworksChanged");
+      await saveFrameworksToBrowser();
+      return updated;
+    }
+
+    const response = await fetch(`/api/frameworks/${id}`, {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(data),
+    });
+    if (!response.ok) {
+      if (response.status === 404) {
+        console.error("Framework not found:", id);
+        return null;
+      }
+      throw new Error(`Failed to update framework: ${response.statusText}`);
+    }
+    const updatedFramework = await response.json();
+    frameworks = frameworks.map(f => (f.id === id ? updatedFramework : f));
+    eventBus.publish("frameworksChanged");
+    syncFrameworksToYjs();
+    return updatedFramework;
+  } catch (error) {
+    console.error("Error updating framework:", error);
+    return null;
+  }
+};
+
+const deleteFramework = async (id: string): Promise<boolean> => {
+  try {
+    frameworks = frameworks.filter(f => f.id !== id);
+    eventBus.publish("frameworksChanged");
+
+    if (PERSISTENCE_CONFIG.FORCE_BROWSER) {
+      await saveFrameworksToBrowser();
+      return true;
+    }
+
+    const response = await fetch(`/api/frameworks/${id}`, { method: "DELETE" });
+    if (!response.ok) {
+      throw new Error(`Failed to delete framework: ${response.statusText}`);
+    }
+    syncFrameworksToYjs();
+    return true;
+  } catch (error) {
+    console.error("Error deleting framework:", error);
+    return false;
+  }
+};
+
+if (typeof window !== 'undefined') {
+  loadFrameworks();
+}
+
+export function useFrameworks(frameworkType?: FrameworkType) {
+  const [, setForceRender] = React.useState({});
+  const [frameworksVersion, setFrameworksVersion] = React.useState(0);
+
+  React.useEffect(() => {
+    initializeCollaboration();
+  }, []);
+
+  React.useEffect(() => {
+    const onFrameworksChanged = () => {
+      setForceRender({});
+      setFrameworksVersion(v => v + 1);
+    };
+    eventBus.subscribe("frameworksChanged", onFrameworksChanged);
+    return () => {
+      eventBus.unsubscribe("frameworksChanged", onFrameworksChanged);
+    };
+  }, []);
+
+  React.useEffect(() => {
+    if (!isCollaborationEnabled()) return;
+
+    const observer = () => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      frameworks = (Array.from(yFrameworks.values()) as any[]).map(v => {
+        if (v && typeof v.toJSON === "function") return v.toJSON();
+        return JSON.parse(JSON.stringify(v));
+      }) as FrameworkEntity[];
+      eventBus.publish("frameworksChanged");
+    };
+
+    yFrameworks.observe(observer);
+    return () => {
+      yFrameworks.unobserve(observer);
+    };
+  }, []);
+
+  const filteredFrameworks = frameworkType
+    ? frameworks.filter(f => f.frameworkType === frameworkType)
+    : frameworks;
+
+  return {
+    frameworks: filteredFrameworks,
+    frameworksVersion,
+    loadFrameworks,
+    createFramework,
+    updateFramework,
+    deleteFramework,
+    getFrameworkById: React.useCallback((id: string): FrameworkEntity | undefined => {
+      return frameworks.find(f => f.id === id);
+    }, []),
+  };
+}

--- a/src/lib/collaboration.ts
+++ b/src/lib/collaboration.ts
@@ -26,6 +26,9 @@ export const yDreamColumns = instrumentYMap(doc.getMap('dreamColumns'), 'dreamCo
 // Export shared circles map for real-time sync
 export const yCircles = instrumentYMap(doc.getMap('circles'), 'circles');
 
+// Export shared frameworks map for real-time sync
+export const yFrameworks = instrumentYMap(doc.getMap('frameworks'), 'frameworks');
+
 // Export shared app settings map for cross-client synchronization
 export const yAppSettings = instrumentYMap(doc.getMap('appSettings'), 'appSettings');
 

--- a/src/lib/persistence-browser.ts
+++ b/src/lib/persistence-browser.ts
@@ -1,4 +1,4 @@
-import { PersistenceAdapter, TaskEntity, UserSettingsEntity, AppSettingsEntity, QolSurveyResponseEntity, FilterStateEntity, StorageMetadata, FertilizationBoardEntity, DreamBoardEntity, ReminderEntity, CircleEntity } from './persistence-types';
+import { PersistenceAdapter, TaskEntity, UserSettingsEntity, AppSettingsEntity, QolSurveyResponseEntity, FilterStateEntity, StorageMetadata, FertilizationBoardEntity, DreamBoardEntity, ReminderEntity, CircleEntity, FrameworkEntity, FrameworkType } from './persistence-types';
 
 // Storage keys
 const TASKS_STORAGE_KEY = 'dyad_task_board_v1';
@@ -10,6 +10,7 @@ const FERTILIZATION_BOARD_STORAGE_KEY = 'fertilizationBoard';
 const DREAM_BOARD_STORAGE_KEY = 'dreamBoard';
 const CIRCLES_STORAGE_KEY = 'p3fo_circles_v1';
 const REMINDERS_STORAGE_KEY = 'p3fo_reminders_v1';
+const FRAMEWORKS_STORAGE_KEY = 'p3fo_frameworks_v1';
 
 // Default values
 const DEFAULT_USER_SETTINGS: UserSettingsEntity = {
@@ -652,6 +653,7 @@ export class BrowserJsonPersistence implements PersistenceAdapter {
       localStorage.removeItem(DREAM_BOARD_STORAGE_KEY);
       localStorage.removeItem(REMINDERS_STORAGE_KEY);
       localStorage.removeItem(CIRCLES_STORAGE_KEY);
+      localStorage.removeItem(FRAMEWORKS_STORAGE_KEY);
       sessionStorage.removeItem(FILTERS_STORAGE_KEY);
 
       // Clear dynamic keys (users and QoL surveys)
@@ -708,6 +710,114 @@ export class BrowserJsonPersistence implements PersistenceAdapter {
       localStorage.setItem(REMINDERS_STORAGE_KEY, JSON.stringify(reminders));
     } catch (error) {
       console.error('Error importing reminders to localStorage:', error);
+      throw error;
+    }
+  }
+
+  // Frameworks
+  async listFrameworks(frameworkType?: FrameworkType): Promise<FrameworkEntity[]> {
+    if (typeof window === 'undefined') {
+      return [];
+    }
+
+    try {
+      const stored = localStorage.getItem(FRAMEWORKS_STORAGE_KEY);
+      const all: FrameworkEntity[] = stored ? JSON.parse(stored) : [];
+      if (frameworkType) {
+        return all.filter(f => f.frameworkType === frameworkType);
+      }
+      return all;
+    } catch (error) {
+      console.error('Error reading frameworks from localStorage:', error);
+      return [];
+    }
+  }
+
+  async getFrameworkById(id: string): Promise<FrameworkEntity | null> {
+    if (typeof window === 'undefined') {
+      return null;
+    }
+
+    try {
+      const frameworks = await this.listFrameworks();
+      return frameworks.find(f => f.id === id) || null;
+    } catch (error) {
+      console.error('Error getting framework from localStorage:', error);
+      return null;
+    }
+  }
+
+  async createFramework(input: Partial<FrameworkEntity>): Promise<FrameworkEntity> {
+    if (typeof window === 'undefined') {
+      throw new Error('Cannot create framework in non-browser environment');
+    }
+
+    try {
+      const frameworks = await this.listFrameworks();
+      const now = new Date().toISOString();
+      const newFramework: FrameworkEntity = {
+        id: input.id || crypto.randomUUID(),
+        name: input.name || 'New Framework',
+        frameworkType: input.frameworkType || 'intentional',
+        parentId: input.parentId ?? null,
+        categories: input.categories || [],
+        createdAt: input.createdAt || now,
+        updatedAt: input.updatedAt || now,
+      };
+      frameworks.push(newFramework);
+      localStorage.setItem(FRAMEWORKS_STORAGE_KEY, JSON.stringify(frameworks));
+      return newFramework;
+    } catch (error) {
+      console.error('Error creating framework in localStorage:', error);
+      throw error;
+    }
+  }
+
+  async updateFramework(id: string, patch: Partial<FrameworkEntity>): Promise<FrameworkEntity | null> {
+    if (typeof window === 'undefined') {
+      throw new Error('Cannot update framework in non-browser environment');
+    }
+
+    try {
+      const frameworks = await this.listFrameworks();
+      const index = frameworks.findIndex(f => f.id === id);
+      if (index === -1) {
+        console.warn('Update framework: not found', id);
+        return null;
+      }
+      frameworks[index] = { ...frameworks[index], ...patch, updatedAt: new Date().toISOString() };
+      localStorage.setItem(FRAMEWORKS_STORAGE_KEY, JSON.stringify(frameworks));
+      return frameworks[index];
+    } catch (error) {
+      console.error('Error updating framework in localStorage:', error);
+      throw error;
+    }
+  }
+
+  async deleteFramework(id: string): Promise<void> {
+    if (typeof window === 'undefined') {
+      return;
+    }
+
+    try {
+      const frameworks = await this.listFrameworks();
+      const filtered = frameworks.filter(f => f.id !== id);
+      localStorage.setItem(FRAMEWORKS_STORAGE_KEY, JSON.stringify(filtered));
+    } catch (error) {
+      console.error('Error deleting framework from localStorage:', error);
+      throw error;
+    }
+  }
+
+  async importFrameworks(frameworks: FrameworkEntity[]): Promise<void> {
+    if (typeof window === 'undefined') {
+      return;
+    }
+
+    try {
+      localStorage.setItem(FRAMEWORKS_STORAGE_KEY, JSON.stringify(frameworks));
+    } catch (error) {
+      console.error('Error importing frameworks to localStorage:', error);
       throw error;
     }
   }

--- a/src/lib/persistence-http.ts
+++ b/src/lib/persistence-http.ts
@@ -1,4 +1,4 @@
-import { PersistenceAdapter, TaskEntity, UserSettingsEntity, AppSettingsEntity, QolSurveyResponseEntity, FilterStateEntity, StorageMetadata, FertilizationBoardEntity, DreamBoardEntity, ReminderEntity, CircleEntity } from './persistence-types';
+import { PersistenceAdapter, TaskEntity, UserSettingsEntity, AppSettingsEntity, QolSurveyResponseEntity, FilterStateEntity, StorageMetadata, FertilizationBoardEntity, DreamBoardEntity, ReminderEntity, CircleEntity, FrameworkEntity, FrameworkType } from './persistence-types';
 import { DEFAULT_TASKS_INITIALIZED_KEY } from '@/hooks/useTasks';
 
 export class HttpApiPersistence implements PersistenceAdapter {
@@ -289,23 +289,18 @@ export class HttpApiPersistence implements PersistenceAdapter {
     // For now, let's assume we can import at module level.
     // But since this is a class method, let's use the valid imports.
     try {
-      const { doc, yTasks, yUserSettings, yFertilizationState, yFertilizationCards, yFertilizationColumns, yDreamState, yDreamCards, yDreamColumns, yCircles, ySystemState } = await import('./collaboration');
+      const { doc, yTasks, yUserSettings, yFertilizationState, yFertilizationCards, yFertilizationColumns, yDreamState, yDreamCards, yDreamColumns, yCircles, yFrameworks, ySystemState } = await import('./collaboration');
       doc.transact(() => {
-        // Clear tasks
         yTasks.clear();
-        // Clear user settings
         yUserSettings.clear();
-        // Clear fertilization board
         yFertilizationState.clear();
         yFertilizationCards.clear();
         yFertilizationColumns.clear();
-        // Clear dream board
         yDreamState.clear();
         yDreamCards.clear();
         yDreamColumns.clear();
-        // Clear circles
         yCircles.clear();
-        // Broadcast clear command to other clients
+        yFrameworks.clear();
         ySystemState.set('command', { type: 'CLEAR_ALL', timestamp: Date.now() });
       });
       console.log('Cleared Yjs shared documents and broadcasted CLEAR_ALL command');
@@ -323,6 +318,43 @@ export class HttpApiPersistence implements PersistenceAdapter {
     await this.makeRequest('/api/circles/import', {
       method: 'POST',
       body: JSON.stringify(circles),
+    });
+  }
+
+  // Frameworks
+  async listFrameworks(frameworkType?: FrameworkType): Promise<FrameworkEntity[]> {
+    const endpoint = frameworkType ? `/api/frameworks?frameworkType=${encodeURIComponent(frameworkType)}` : '/api/frameworks';
+    return this.makeRequest(endpoint);
+  }
+
+  async getFrameworkById(id: string): Promise<FrameworkEntity | null> {
+    return this.makeRequest(`/api/frameworks/${id}`);
+  }
+
+  async createFramework(input: Partial<FrameworkEntity>): Promise<FrameworkEntity> {
+    return this.makeRequest('/api/frameworks', {
+      method: 'POST',
+      body: JSON.stringify(input),
+    });
+  }
+
+  async updateFramework(id: string, patch: Partial<FrameworkEntity>): Promise<FrameworkEntity | null> {
+    return this.makeRequest(`/api/frameworks/${id}`, {
+      method: 'PATCH',
+      body: JSON.stringify(patch),
+    });
+  }
+
+  async deleteFramework(id: string): Promise<void> {
+    await this.makeRequest(`/api/frameworks/${id}`, {
+      method: 'DELETE',
+    });
+  }
+
+  async importFrameworks(frameworks: FrameworkEntity[]): Promise<void> {
+    await this.makeRequest('/api/frameworks/import', {
+      method: 'POST',
+      body: JSON.stringify(frameworks),
     });
   }
 

--- a/src/lib/persistence-types.ts
+++ b/src/lib/persistence-types.ts
@@ -75,7 +75,9 @@ export type ModuleId =
   | 'plan.circles'
   | 'plan.roles'
   | 'program.calendar'
-  | 'program.resources';
+  | 'program.resources'
+  | 'dream.intentionalFramework'
+  | 'dream.collaborativeFramework';
 
 export interface AppSettingsEntity {
   splitTime: number;
@@ -195,6 +197,14 @@ export interface PersistenceAdapter {
   // Circles
   listCircles(): Promise<CircleEntity[]>;
   importCircles(circles: CircleEntity[]): Promise<void>;
+
+  // Frameworks
+  listFrameworks(frameworkType?: FrameworkType): Promise<FrameworkEntity[]>;
+  getFrameworkById(id: string): Promise<FrameworkEntity | null>;
+  createFramework(input: Partial<FrameworkEntity>): Promise<FrameworkEntity>;
+  updateFramework(id: string, patch: Partial<FrameworkEntity>): Promise<FrameworkEntity | null>;
+  deleteFramework(id: string): Promise<void>;
+  importFrameworks(frameworks: FrameworkEntity[]): Promise<void>;
 }
 
 export type FactTag = 'A' | 'N' | 'K' | 'P';
@@ -314,6 +324,27 @@ export interface ReminderEntity {
   snoozeDurationMinutes?: number;
   originalTriggerDate?: string;
   state: 'scheduled' | 'triggered' | 'read' | 'dismissed';
+  createdAt: string;
+  updatedAt: string;
+}
+
+export type FrameworkType = 'intentional' | 'collaborative';
+
+export interface FrameworkCategory {
+  id: string;
+  label: string;
+  description: string;
+  optional?: boolean;
+  content: string;
+  order: number;
+}
+
+export interface FrameworkEntity {
+  id: string;
+  name: string;
+  frameworkType: FrameworkType;
+  parentId: string | null;
+  categories: FrameworkCategory[];
   createdAt: string;
   updatedAt: string;
 }


### PR DESCRIPTION
- Add framework data model with intentional and collaborative types, supporting hierarchical parent-child relationships
- Add full CRUD REST API endpoints for frameworks (list, get, create, update, delete, import)
- Implement framework persistence in both SQLite and PostgreSQL with proper indexing
- Add collaborative framework view with predefined categories (values, behaviors, meetings, entry/exit, conflict resolution, etc.)
- Add intentional framework view with purpose, priorities, strategies, and key metrics categories
- Add framework category editor component with focus mode integration
- Add useFrameworks hook for client-side framework state management
- Integrate frameworks into dream top view, umbrella navigation, data import/export, and browser/HTTP persistence layers
- Add repository metadata to package.json

Closes #80